### PR TITLE
feat(ocm): Harmonise artefact type handling and support "OCI-native" local blobs

### DIFF
--- a/src/cli/_bdba.py
+++ b/src/cli/_bdba.py
@@ -6,10 +6,7 @@ import pprint
 
 import tabulate
 
-import cnudie.access
-import ocm
 import ocm.iter
-import tarutil
 
 import bdba.client
 import bdba.model as bm
@@ -98,12 +95,6 @@ def scan(
     oci_client = lookups.semver_sanitising_oci_client(
         secret_factory=secret_factory,
     )
-    if aws_cfg_name:
-        aws_cfg = secret_factory.aws(aws_cfg_name)
-        s3_client = aws_cfg.session.client('s3')
-    else:
-        s3_client = None
-        logger.warning('failed to initialise s3-client')
 
     if not bdba_api_url:
         bdba_api_url = bdba_cfg.api_url
@@ -151,45 +142,12 @@ def scan(
                 group_id=bdba_group_id,
             )
 
-            access = resource_node.resource.access
-
-            if access.type is ocm.AccessType.OCI_REGISTRY:
-                content_iterator = ocm_util.image_layers_as_tarfile_generator(
-                    image_reference=access.imageReference,
-                    oci_client=oci_client,
-                    include_config_blob=False,
-                    fallback_to_first_subimage_if_index=True,
-                )
-
-            elif access.type is ocm.AccessType.S3:
-                content_iterator = tarutil.concat_blobs_as_tarstream(
-                    blobs=[
-                        cnudie.access.s3_access_as_blob_descriptor(
-                            s3_client=s3_client,
-                            s3_access=access,
-                        ),
-                    ],
-                )
-
-            elif access.type is ocm.AccessType.LOCAL_BLOB:
-                ocm_repo = resource_node.component.current_ocm_repo
-                image_reference = ocm_repo.component_version_oci_ref(
-                    name=resource_node.component.name,
-                    version=resource_node.component.version,
-                )
-
-                content_iterator = tarutil.concat_blobs_as_tarstream(
-                    blobs=[
-                        ocm_util.local_blob_access_as_blob_descriptor(
-                            access=access,
-                            oci_client=oci_client,
-                            image_reference=image_reference,
-                        ),
-                    ],
-                )
-
-            else:
-                raise NotImplementedError(access)
+            content_iterator = ocm_util.iter_content_for_resource_node(
+                resource_node=resource_node,
+                oci_client=oci_client,
+                secret_factory=secret_factory,
+                aws_secret_name=aws_cfg_name,
+            )
 
             yield from processor.process(
                 resource_node=resource_node,

--- a/src/components.py
+++ b/src/components.py
@@ -3,7 +3,6 @@ import dataclasses
 import datetime
 import dataclasses_json
 import http
-import io
 import logging
 import tarfile
 import zlib
@@ -12,7 +11,6 @@ import aiohttp.web
 import dacite.exceptions
 import sqlalchemy as sa
 import sqlalchemy.ext.asyncio as sqlasync
-import yaml
 
 import cnudie.retrieve
 import cnudie.retrieve_async
@@ -23,7 +21,6 @@ import oci.model as om
 import ocm
 import ocm.iter
 import ocm.iter_async
-import ocm.oci
 import ocm.util
 
 import compliance_summary as cs
@@ -33,6 +30,7 @@ import deliverydb.model as dm
 import deliverydb.util as du
 import features
 import lookups
+import ocm_util
 import odg.model
 import responsibles
 import responsibles.labels
@@ -142,15 +140,23 @@ async def _component_descriptor(
     else:
         ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
 
-    ocm_repos = list(ocm_repository_lookup(component_name))
-
     if raw or ignore_cache:
         # in both cases fetch directly from oci-registry
+        ocm_repos = list(ocm_repository_lookup(component_name))
+        oci_client = lookups.semver_sanitising_oci_client_async()
+
         try:
-            raw = await cnudie.retrieve_async.raw_component_descriptor_from_oci(
+            if raw:
+                return await ocm_util.raw_component_descriptor_from_oci_async(
+                    component_id=component_id,
+                    ocm_repos=ocm_repos,
+                    oci_client=oci_client,
+                )
+
+            return await cnudie.retrieve_async.component_descriptor_from_oci(
                 component_id=component_id,
                 ocm_repos=ocm_repos,
-                oci_client=lookups.semver_sanitising_oci_client_async(),
+                oci_client=oci_client,
             )
 
         except om.OciImageNotFoundException:
@@ -161,28 +167,6 @@ async def _component_descriptor(
                     f'"{component_id.version}" not found in {ocm_repo=}'
                 ),
             )
-
-        # wrap in fobj
-        blob_fobj = io.BytesIO(raw)
-
-        with tarfile.open(fileobj=blob_fobj, mode='r') as tf:
-            component_descriptor_info = tf.getmember(ocm.oci.component_descriptor_fname)
-            component_descriptor_bytes = tf.extractfile(component_descriptor_info).read()
-
-        if raw:
-            component_descriptor = component_descriptor_bytes.decode()
-
-        else:
-            try:
-                component_descriptor = ocm.ComponentDescriptor.from_dict(
-                    yaml.safe_load(component_descriptor_bytes),
-                )
-            except dacite.exceptions.MissingValueError as e:
-                raise aiohttp.web.HTTPFailedDependency(
-                    reason=str(e),
-                )
-
-        return component_descriptor
 
     try:
         descriptor = await util.retrieve_component_descriptor(

--- a/src/crypto_extension/cbom.py
+++ b/src/crypto_extension/cbom.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 
 import oci.client
+import oci.model
 import ocm
 
 import syft
@@ -91,9 +92,36 @@ def find_cbom_or_create(
         with open(sbom_path, 'w') as file:
             file.write(sbom_raw)
 
+        image_reference = None
+
         if access.type is ocm.AccessType.OCI_REGISTRY:
+            access: ocm.OciAccess
+
+            image_reference = access.imageReference
+
+        elif access.type is ocm.AccessType.LOCAL_BLOB and access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            access: ocm.LocalBlobAccess | ocm.OciBlobAccess
+
+            image_reference = component.current_ocm_repo.component_version_oci_ref(
+                name=component.name,
+                version=component.version,
+            )
+
+            if access.type is ocm.AccessType.LOCAL_BLOB:
+                digest = access.localReference.lower()
+            else:
+                digest = access.digest.lower()
+
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+        if image_reference:
             cbom = create_cbom(
-                image=access.imageReference,
+                image=image_reference,
                 sbom_path=sbom_path,
             )
 

--- a/src/crypto_extension/cbom.py
+++ b/src/crypto_extension/cbom.py
@@ -72,6 +72,7 @@ def find_cbom_or_create(
     with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
         filename_for_access_type = {
             ocm.AccessType.LOCAL_BLOB: 'local_blob',
+            ocm.AccessType.OCI_BLOB: 'oci_blob',
             ocm.AccessType.S3: 's3',
         }
 
@@ -99,7 +100,10 @@ def find_cbom_or_create(
 
             image_reference = access.imageReference
 
-        elif access.type is ocm.AccessType.LOCAL_BLOB and access.mediaType in (
+        elif access.type in (
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+        ) and access.mediaType in (
             oci.model.OCI_IMAGE_INDEX_MIME,
             oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
             oci.model.DOCKER_MANIFEST_LIST_MIME,

--- a/src/malware/__main__.py
+++ b/src/malware/__main__.py
@@ -36,16 +36,20 @@ def scan_resource(
     aws_secret_name: str | None,
     secret_factory: secret_mgmt.SecretFactory,
 ) -> collections.abc.Generator[odg.model.ClamAVMalwareFinding, None, None]:
-    resource: ocm.Resource = resource_node.resource
+    access = resource_node.resource.access
 
-    if resource.access.type is ocm.AccessType.OCI_REGISTRY:
-        results = malware.scan.scan_oci_image(
-            image_reference=resource.access.imageReference,
+    if access.type is ocm.AccessType.OCI_REGISTRY:
+        access: ocm.OciAccess
+
+        return malware.scan.scan_oci_image(
+            image_reference=access.imageReference,
             oci_client=oci_client,
             malware_cfg=malware_cfg,
         )
 
-    elif resource.access.type is ocm.AccessType.S3:
+    elif access.type is ocm.AccessType.S3:
+        access: ocm.S3Access | ocm.LegacyS3Access
+
         aws_secret = secret_mgmt.aws.find_cfg(
             secret_factory=secret_factory,
             secret_name=aws_secret_name,
@@ -57,37 +61,56 @@ def scan_resource(
         ):
             raise NotImplementedError(resource.type)
 
-        if isinstance(resource.access, ocm.LegacyS3Access):
-            bucket = resource.access.bucketName
-            key = resource.access.objectKey
+        if isinstance(access, ocm.LegacyS3Access):
+            bucket = access.bucketName
+            key = access.objectKey
         else:
-            bucket = resource.access.bucket
-            key = resource.access.key
+            bucket = access.bucket
+            key = access.key
 
         fileobj = s3_client.Object(bucket, key).get()['Body']
 
         tf = tarfile.open(fileobj=fileobj, mode='r|*')
-        results = malware.scan.scan_tarfile(
+        return malware.scan.scan_tarfile(
             malware_cfg=malware_cfg,
             tf=tf,
             context=f'{bucket}|{key}',
         )
 
-    elif resource.access.type is ocm.AccessType.LOCAL_BLOB:
-        if resource.access.globalAccess:
-            image_reference = resource.access.globalAccess.ref
-            digest = resource.access.globalAccess.digest
-            size = resource.access.globalAccess.size
-        else:
-            ocm_repo = resource_node.component.current_ocm_repo
-            image_reference = ocm_repo.component_oci_ref(resource_node.component.name)
-            digest = resource.access.localReference
-            size = resource.access.size
+    elif access.type is ocm.AccessType.LOCAL_BLOB:
+        access: ocm.LocalBlobAccess
 
-        results = malware.scan.scan_oci_blob(
+        image_reference = resource_node.component.current_ocm_repo.component_version_oci_ref(
+            name=resource_node.component.name,
+            version=resource_node.component.version,
+        )
+        digest = access.localReference.lower()
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return malware.scan.scan_oci_image(
+                image_reference=image_reference,
+                oci_client=oci_client,
+                malware_cfg=malware_cfg,
+            )
+
+        if access.globalAccess:
+            image_reference = access.globalAccess.ref
+            digest = access.globalAccess.digest
+            size = access.globalAccess.size
+        else:
+            size = access.size
+
+        return malware.scan.scan_oci_blob(
             blob_reference=oci.model.OciBlobRef(
                 digest=digest,
-                mediaType=resource.access.mediaType,
+                mediaType=access.mediaType,
                 size=size,
             ),
             image_reference=image_reference,
@@ -96,11 +119,7 @@ def scan_resource(
         )
 
     else:
-        raise RuntimeError(
-            resource.access.type,
-        )  # we filtered supported access types already earlier
-
-    return results
+        raise RuntimeError(access.type)  # we filtered supported access types already earlier
 
 
 def _iter_clamav_malware_findings(

--- a/src/malware/__main__.py
+++ b/src/malware/__main__.py
@@ -120,6 +120,41 @@ def scan_resource(
             malware_cfg=malware_cfg,
         )
 
+    elif access.type is ocm.AccessType.OCI_BLOB:
+        access: ocm.OciBlobAccess
+
+        ocm_repo = resource_node.component.current_ocm_repo
+        image_reference = ocm_repo.component_version_oci_ref(
+            name=resource_node.component.name,
+            version=resource_node.component.version,
+        )
+        digest = access.digest.lower()
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return malware.scan.scan_oci_image(
+                image_reference=image_reference,
+                oci_client=oci_client,
+                malware_cfg=malware_cfg,
+            )
+
+        return malware.scan.scan_oci_blob(
+            blob_reference=oci.model.OciBlobRef(
+                digest=digest,
+                mediaType=access.mediaType,
+                size=access.size,
+            ),
+            image_reference=image_reference,
+            oci_client=oci_client,
+            malware_cfg=malware_cfg,
+        )
+
     else:
         raise RuntimeError(access.type)  # we filtered supported access types already earlier
 

--- a/src/malware/__main__.py
+++ b/src/malware/__main__.py
@@ -22,6 +22,7 @@ import odg_client
 import paths
 import secret_mgmt
 import secret_mgmt.aws
+import util
 
 
 logger = logging.getLogger(__name__)
@@ -50,16 +51,17 @@ def scan_resource(
     elif access.type is ocm.AccessType.S3:
         access: ocm.S3Access | ocm.LegacyS3Access
 
+        if hasattr(access, 'mediaType') and access.mediaType:
+            if not util.media_type_supports(access.mediaType, 'tar'):
+                raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
+        elif not util.media_type_supports(resource_node.resource.type, 'tar'):
+            logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
+
         aws_secret = secret_mgmt.aws.find_cfg(
             secret_factory=secret_factory,
             secret_name=aws_secret_name,
         )
         s3_client = aws_secret.session.resource('s3')
-
-        if not resource.type.startswith('application/tar') and not resource.type.startswith(
-            'application/x-tar',
-        ):
-            raise NotImplementedError(resource.type)
 
         if isinstance(access, ocm.LegacyS3Access):
             bucket = access.bucketName

--- a/src/malware/__main__.py
+++ b/src/malware/__main__.py
@@ -30,6 +30,91 @@ ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
 
 
+def _scan_s3(
+    access: ocm.S3Access | ocm.LegacyS3Access,
+    resource_type: str,
+    malware_cfg: odg.findings.Finding,
+    aws_secret_name: str | None,
+    secret_factory: secret_mgmt.SecretFactory,
+) -> collections.abc.Generator[odg.model.ClamAVMalwareFinding, None, None]:
+    if hasattr(access, 'mediaType') and access.mediaType:
+        if not util.media_type_supports(access.mediaType, 'tar'):
+            raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
+    elif not util.media_type_supports(resource_type, 'tar'):
+        logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
+
+    aws_secret = secret_mgmt.aws.find_cfg(
+        secret_factory=secret_factory,
+        secret_name=aws_secret_name,
+    )
+    s3_client = aws_secret.session.resource('s3')
+
+    if isinstance(access, ocm.LegacyS3Access):
+        bucket = access.bucketName
+        key = access.objectKey
+    else:
+        bucket = access.bucket
+        key = access.key
+
+    fileobj = s3_client.Object(bucket, key).get()['Body']
+
+    tf = tarfile.open(fileobj=fileobj, mode='r|*')
+    return malware.scan.scan_tarfile(
+        malware_cfg=malware_cfg,
+        tf=tf,
+        context=f'{bucket}|{key}',
+    )
+
+
+def _scan_blob(
+    access: ocm.LocalBlobAccess | ocm.OciBlobAccess,
+    component: ocm.Component,
+    oci_client: oci.client.Client,
+    malware_cfg: odg.findings.Finding,
+) -> collections.abc.Generator[odg.model.ClamAVMalwareFinding, None, None]:
+    image_reference = component.current_ocm_repo.component_version_oci_ref(
+        name=component.name,
+        version=component.version,
+    )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB:
+        digest = access.localReference.lower()
+    else:
+        digest = access.digest.lower()
+
+    if access.mediaType in (
+        oci.model.OCI_IMAGE_INDEX_MIME,
+        oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+        oci.model.DOCKER_MANIFEST_LIST_MIME,
+        oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+    ):
+        image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+        return malware.scan.scan_oci_image(
+            image_reference=image_reference,
+            oci_client=oci_client,
+            malware_cfg=malware_cfg,
+        )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB and access.globalAccess:
+        image_reference = access.globalAccess.ref
+        digest = access.globalAccess.digest.lower()
+        size = access.globalAccess.size
+    else:
+        size = access.size
+
+    return malware.scan.scan_oci_blob(
+        blob_reference=oci.model.OciBlobRef(
+            digest=digest,
+            mediaType=access.mediaType,
+            size=size,
+        ),
+        image_reference=image_reference,
+        oci_client=oci_client,
+        malware_cfg=malware_cfg,
+    )
+
+
 def scan_resource(
     resource_node: ocm.iter.ResourceNode,
     malware_cfg: odg.findings.Finding,
@@ -49,108 +134,21 @@ def scan_resource(
         )
 
     elif access.type is ocm.AccessType.S3:
-        access: ocm.S3Access | ocm.LegacyS3Access
-
-        if hasattr(access, 'mediaType') and access.mediaType:
-            if not util.media_type_supports(access.mediaType, 'tar'):
-                raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
-        elif not util.media_type_supports(resource_node.resource.type, 'tar'):
-            logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
-
-        aws_secret = secret_mgmt.aws.find_cfg(
+        return _scan_s3(
+            access=access,
+            resource_type=resource_node.resource.type,
+            malware_cfg=malware_cfg,
+            aws_secret_name=aws_secret_name,
             secret_factory=secret_factory,
-            secret_name=aws_secret_name,
-        )
-        s3_client = aws_secret.session.resource('s3')
-
-        if isinstance(access, ocm.LegacyS3Access):
-            bucket = access.bucketName
-            key = access.objectKey
-        else:
-            bucket = access.bucket
-            key = access.key
-
-        fileobj = s3_client.Object(bucket, key).get()['Body']
-
-        tf = tarfile.open(fileobj=fileobj, mode='r|*')
-        return malware.scan.scan_tarfile(
-            malware_cfg=malware_cfg,
-            tf=tf,
-            context=f'{bucket}|{key}',
         )
 
-    elif access.type is ocm.AccessType.LOCAL_BLOB:
-        access: ocm.LocalBlobAccess
-
-        image_reference = resource_node.component.current_ocm_repo.component_version_oci_ref(
-            name=resource_node.component.name,
-            version=resource_node.component.version,
-        )
-        digest = access.localReference.lower()
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return malware.scan.scan_oci_image(
-                image_reference=image_reference,
-                oci_client=oci_client,
-                malware_cfg=malware_cfg,
-            )
-
-        if access.globalAccess:
-            image_reference = access.globalAccess.ref
-            digest = access.globalAccess.digest
-            size = access.globalAccess.size
-        else:
-            size = access.size
-
-        return malware.scan.scan_oci_blob(
-            blob_reference=oci.model.OciBlobRef(
-                digest=digest,
-                mediaType=access.mediaType,
-                size=size,
-            ),
-            image_reference=image_reference,
-            oci_client=oci_client,
-            malware_cfg=malware_cfg,
-        )
-
-    elif access.type is ocm.AccessType.OCI_BLOB:
-        access: ocm.OciBlobAccess
-
-        ocm_repo = resource_node.component.current_ocm_repo
-        image_reference = ocm_repo.component_version_oci_ref(
-            name=resource_node.component.name,
-            version=resource_node.component.version,
-        )
-        digest = access.digest.lower()
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return malware.scan.scan_oci_image(
-                image_reference=image_reference,
-                oci_client=oci_client,
-                malware_cfg=malware_cfg,
-            )
-
-        return malware.scan.scan_oci_blob(
-            blob_reference=oci.model.OciBlobRef(
-                digest=digest,
-                mediaType=access.mediaType,
-                size=access.size,
-            ),
-            image_reference=image_reference,
+    elif access.type in (
+        ocm.AccessType.LOCAL_BLOB,
+        ocm.AccessType.OCI_BLOB,
+    ):
+        return _scan_blob(
+            access=access,
+            component=resource_node.component,
             oci_client=oci_client,
             malware_cfg=malware_cfg,
         )

--- a/src/malware/__main__.py
+++ b/src/malware/__main__.py
@@ -185,16 +185,12 @@ def scan_and_upload(
         artefact=artefact,
     )
     access_type = resource_node.resource.access.type
-    resource_type = resource_node.resource.type
 
-    if not extension_cfg.is_supported(
-        access_type=access_type,
-        artefact_type=resource_type,
-    ):
+    if not extension_cfg.is_supported(access_type=access_type):
         if extension_cfg.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
             raise TypeError(
-                f'{access_type=} with {resource_type=} is not supported by the ClamAV extension, '
-                'maybe the filter configurations have to be adjusted to filter out these types',
+                f'{access_type=} is not supported by the ClamAV extension, maybe the filter '
+                'configurations have to be adjusted to filter out these types',
             )
         return
 

--- a/src/ocm_util.py
+++ b/src/ocm_util.py
@@ -74,6 +74,27 @@ def local_blob_access_as_blob_descriptor(
     )
 
 
+def oci_blob_access_as_blob_descriptor(
+    access: ocm.OciBlobAccess,
+    oci_client: oci.client.Client,
+    image_reference: str,
+) -> ioutil.BlobDescriptor:
+    digest = access.digest.lower()
+    size = access.size
+
+    blob = oci_client.blob(
+        image_reference=image_reference,
+        digest=digest,
+        stream=True,
+    )
+
+    return ioutil.BlobDescriptor(
+        content=blob.iter_content(chunk_size=4096),
+        size=size,
+        name=f'{digest}.tar',
+    )
+
+
 async def find_artefact_node_async(
     component_descriptor_lookup: cnudie.retrieve_async.ComponentDescriptorLookupById,
     artefact: odg.model.ComponentArtefactId,
@@ -236,6 +257,41 @@ def iter_content_for_resource_node(
         return tarutil.concat_blobs_as_tarstream(
             blobs=[
                 local_blob_access_as_blob_descriptor(
+                    access=access,
+                    oci_client=oci_client,
+                    image_reference=image_reference,
+                ),
+            ],
+        )
+
+    elif access.type is ocm.AccessType.OCI_BLOB:
+        access: ocm.OciBlobAccess
+
+        ocm_repo = resource_node.component.current_ocm_repo
+        image_reference = ocm_repo.component_version_oci_ref(
+            name=resource_node.component.name,
+            version=resource_node.component.version,
+        )
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            digest = access.digest.lower()
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return image_layers_as_tarfile_generator(
+                image_reference=image_reference,
+                oci_client=oci_client,
+                include_config_blob=False,
+                fallback_to_first_subimage_if_index=True,
+            )
+
+        return tarutil.concat_blobs_as_tarstream(
+            blobs=[
+                oci_blob_access_as_blob_descriptor(
                     access=access,
                     oci_client=oci_client,
                     image_reference=image_reference,

--- a/src/ocm_util.py
+++ b/src/ocm_util.py
@@ -193,6 +193,73 @@ def find_artefact_node(
         )
 
 
+def _iter_content_for_s3(
+    access: ocm.S3Access | ocm.LegacyS3Access,
+    secret_factory: secret_mgmt.SecretFactory,
+    aws_secret_name: str | None = None,
+) -> collections.abc.Iterator[bytes]:
+    aws_secret = secret_mgmt.aws.find_cfg(
+        secret_factory=secret_factory,
+        secret_name=aws_secret_name,
+    )
+    s3_client = aws_secret.session.client('s3')
+
+    return tarutil.concat_blobs_as_tarstream(
+        blobs=[
+            cnudie.access.s3_access_as_blob_descriptor(
+                s3_client=s3_client,
+                s3_access=access,
+            ),
+        ],
+    )
+
+
+def _iter_content_for_blob(
+    access: ocm.LocalBlobAccess | ocm.OciBlobAccess,
+    component: ocm.Component,
+    oci_client: oci.client.Client,
+) -> collections.abc.Iterator[bytes]:
+    image_reference = component.current_ocm_repo.component_version_oci_ref(
+        name=component.name,
+        version=component.version,
+    )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB:
+        digest = access.localReference.lower()
+    else:
+        digest = access.digest.lower()
+
+    if access.mediaType in (
+        oci.model.OCI_IMAGE_INDEX_MIME,
+        oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+        oci.model.DOCKER_MANIFEST_LIST_MIME,
+        oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+    ):
+        image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+        return image_layers_as_tarfile_generator(
+            image_reference=image_reference,
+            oci_client=oci_client,
+            include_config_blob=False,
+            fallback_to_first_subimage_if_index=True,
+        )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB:
+        blob_descriptor = local_blob_access_as_blob_descriptor(
+            access=access,
+            oci_client=oci_client,
+            image_reference=image_reference,
+        )
+    else:
+        blob_descriptor = oci_blob_access_as_blob_descriptor(
+            access=access,
+            oci_client=oci_client,
+            image_reference=image_reference,
+        )
+
+    return tarutil.concat_blobs_as_tarstream(blobs=[blob_descriptor])
+
+
 def iter_content_for_resource_node(
     resource_node: ocm.iter.ResourceNode,
     oci_client: oci.client.Client,
@@ -212,91 +279,20 @@ def iter_content_for_resource_node(
         )
 
     elif access.type is ocm.AccessType.S3:
-        access: ocm.S3Access | ocm.LegacyS3Access
-
-        aws_secret = secret_mgmt.aws.find_cfg(
+        return _iter_content_for_s3(
+            access=access,
             secret_factory=secret_factory,
-            secret_name=aws_secret_name,
-        )
-        s3_client = aws_secret.session.client('s3')
-
-        return tarutil.concat_blobs_as_tarstream(
-            blobs=[
-                cnudie.access.s3_access_as_blob_descriptor(
-                    s3_client=s3_client,
-                    s3_access=access,
-                ),
-            ],
+            aws_secret_name=aws_secret_name,
         )
 
-    elif access.type is ocm.AccessType.LOCAL_BLOB:
-        access: ocm.LocalBlobAccess
-
-        ocm_repo = resource_node.component.current_ocm_repo
-        image_reference = ocm_repo.component_version_oci_ref(
-            name=resource_node.component.name,
-            version=resource_node.component.version,
-        )
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            digest = access.localReference.lower()
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return image_layers_as_tarfile_generator(
-                image_reference=image_reference,
-                oci_client=oci_client,
-                include_config_blob=False,
-                fallback_to_first_subimage_if_index=True,
-            )
-
-        return tarutil.concat_blobs_as_tarstream(
-            blobs=[
-                local_blob_access_as_blob_descriptor(
-                    access=access,
-                    oci_client=oci_client,
-                    image_reference=image_reference,
-                ),
-            ],
-        )
-
-    elif access.type is ocm.AccessType.OCI_BLOB:
-        access: ocm.OciBlobAccess
-
-        ocm_repo = resource_node.component.current_ocm_repo
-        image_reference = ocm_repo.component_version_oci_ref(
-            name=resource_node.component.name,
-            version=resource_node.component.version,
-        )
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            digest = access.digest.lower()
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return image_layers_as_tarfile_generator(
-                image_reference=image_reference,
-                oci_client=oci_client,
-                include_config_blob=False,
-                fallback_to_first_subimage_if_index=True,
-            )
-
-        return tarutil.concat_blobs_as_tarstream(
-            blobs=[
-                oci_blob_access_as_blob_descriptor(
-                    access=access,
-                    oci_client=oci_client,
-                    image_reference=image_reference,
-                ),
-            ],
+    elif access.type in (
+        ocm.AccessType.LOCAL_BLOB,
+        ocm.AccessType.OCI_BLOB,
+    ):
+        return _iter_content_for_blob(
+            access=access,
+            component=resource_node.component,
+            oci_client=oci_client,
         )
 
     else:

--- a/src/ocm_util.py
+++ b/src/ocm_util.py
@@ -9,6 +9,7 @@ import oci.client
 import oci.model
 import ocm
 import ocm.iter
+import ocm.oci
 import tarutil
 
 import odg.model
@@ -49,7 +50,15 @@ def local_blob_access_as_blob_descriptor(
         )
 
         if isinstance(manifest, oci.model.OciImageManifestList):
-            raise ValueError('component-descriptor manifest must not be a manifest list')
+            component_descriptor_manifest_digest = ocm.oci.find_component_descriptor_manifest_digest(
+                index_manifest=manifest,
+            )
+
+            manifest = oci_client.manifest(
+                image_reference=oci.model.OciImageReference(image_reference).with_tag(
+                    tag=component_descriptor_manifest_digest,
+                ),
+            )
 
         for layer in manifest.layers:
             if layer.digest == digest:
@@ -172,6 +181,8 @@ def iter_content_for_resource_node(
     access = resource_node.resource.access
 
     if access.type is ocm.AccessType.OCI_REGISTRY:
+        access: ocm.OciAccess
+
         return image_layers_as_tarfile_generator(
             image_reference=access.imageReference,
             oci_client=oci_client,
@@ -180,6 +191,8 @@ def iter_content_for_resource_node(
         )
 
     elif access.type is ocm.AccessType.S3:
+        access: ocm.S3Access | ocm.LegacyS3Access
+
         aws_secret = secret_mgmt.aws.find_cfg(
             secret_factory=secret_factory,
             secret_name=aws_secret_name,
@@ -196,11 +209,29 @@ def iter_content_for_resource_node(
         )
 
     elif access.type is ocm.AccessType.LOCAL_BLOB:
+        access: ocm.LocalBlobAccess
+
         ocm_repo = resource_node.component.current_ocm_repo
         image_reference = ocm_repo.component_version_oci_ref(
             name=resource_node.component.name,
             version=resource_node.component.version,
         )
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            digest = access.localReference.lower()
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return image_layers_as_tarfile_generator(
+                image_reference=image_reference,
+                oci_client=oci_client,
+                include_config_blob=False,
+                fallback_to_first_subimage_if_index=True,
+            )
 
         return tarutil.concat_blobs_as_tarstream(
             blobs=[
@@ -217,7 +248,7 @@ def iter_content_for_resource_node(
 
 
 def image_layers_as_tarfile_generator(
-    image_reference: str,
+    image_reference: str | oci.model.OciImageReference,
     oci_client: oci.client.Client,
     chunk_size=tarfile.RECORDSIZE,
     include_config_blob=True,

--- a/src/ocm_util.py
+++ b/src/ocm_util.py
@@ -1,11 +1,15 @@
 import collections.abc
+import io
 import logging
 import tarfile
+
+import dacite
 
 import cnudie.access
 import cnudie.retrieve_async
 import ioutil
 import oci.client
+import oci.client_async
 import oci.model
 import ocm
 import ocm.iter
@@ -364,3 +368,86 @@ def image_layers_as_tarfile_generator(
             for blob_ref in blob_refs
         ),
     )
+
+
+async def raw_component_descriptor_from_oci_async(
+    component_id: ocm.ComponentIdentity,
+    ocm_repos: collections.abc.Iterable[ocm.OciOcmRepository | str],
+    oci_client: oci.client_async.Client,
+    absent_ok: bool = False,
+) -> str | None:
+    for ocm_repo in ocm_repos:
+        if isinstance(ocm_repo, str):
+            ocm_repo = ocm.OciOcmRepository(
+                baseUrl=ocm_repo,
+            )
+
+        if not isinstance(ocm_repo, ocm.OciOcmRepository):
+            raise NotImplementedError(ocm_repo)
+
+        target_ref = ocm_repo.component_version_oci_ref(component_id)
+
+        manifest = await oci_client.manifest(
+            image_reference=target_ref,
+            absent_ok=True,
+            accept=f'{oci.model.OCI_MANIFEST_SCHEMA_V2_MIME}, {oci.model.OCI_IMAGE_INDEX_MIME}',
+        )
+
+        if not manifest:
+            continue
+
+        if manifest.mediaType == oci.model.OCI_IMAGE_INDEX_MIME:
+            digest = ocm.oci.find_component_descriptor_manifest_digest(manifest)
+
+            manifest = await oci_client.manifest(
+                image_reference=oci.model.OciImageReference(target_ref).with_tag(digest),
+                accept=oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            )
+
+        break
+    else:
+        if absent_ok:
+            return None
+        raise oci.model.OciImageNotFoundException
+
+    try:
+        cfg_blob = await oci_client.blob(
+            image_reference=target_ref,
+            digest=manifest.config.digest,
+        )
+        cfg_dict = await cfg_blob.json(content_type='application/octet-stream')
+        cfg = dacite.from_dict(
+            data_class=ocm.oci.ComponentDescriptorOciCfg,
+            data=cfg_dict,
+        )
+        layer_digest = cfg.componentDescriptorLayer.digest
+        layer_mimetype = cfg.componentDescriptorLayer.mediaType
+    except Exception as e:
+        logger.warning(
+            f'Failed to parse or retrieve component-descriptor-cfg: {e=}. '
+            'falling back to single-layer',
+        )
+
+        # by contract, there must be exactly one layer (tar w/ component-descriptor)
+        if (layers_count := len(manifest.layers)) != 1:
+            logger.warning(f'XXX unexpected amount of {layers_count=}')
+
+        layer_digest = manifest.layers[0].digest
+        layer_mimetype = manifest.layers[0].mediaType
+
+    blob = await oci_client.blob(
+        image_reference=target_ref,
+        digest=layer_digest,
+    )
+    component_descriptor_blob = await blob.content.read()
+
+    if '+tar' in layer_mimetype:
+        try:
+            with tarfile.open(fileobj=io.BytesIO(component_descriptor_blob), mode='r') as tf:
+                component_descriptor_info = tf.getmember(ocm.oci.component_descriptor_fname)
+                component_descriptor_blob = tf.extractfile(component_descriptor_info).read()
+        except tarfile.ReadError as tre:
+            tre.add_note(f'{component_id=}')
+            raise tre
+
+    return component_descriptor_blob.decode()

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -414,7 +414,7 @@ class BlackDuckConfig(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
-        artefact_type: str | None = None,
+        artefact_type: ocm.ArtefactType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
@@ -422,11 +422,14 @@ class BlackDuckConfig(BacklogItemMixins):
             ocm.AccessType.LOCAL_BLOB,
             ocm.AccessType.S3,
         )
-        supported_artefact_types_by_access_type = {
-            ocm.AccessType.OCI_REGISTRY: ('ociImage', 'ociArtifact'),
-            ocm.AccessType.LOCAL_BLOB: ('directoryTree', 'executable'),
-            ocm.AccessType.S3: ('application/tar', 'application/x-tar'),
-        }
+        supported_artefact_types = (
+            ocm.ArtefactType.DIRECTORY_TREE,
+            ocm.ArtefactType.EXECUTABLE,
+            ocm.ArtefactType.OCI_ARTEFACT,
+            ocm.ArtefactType.OCI_IMAGE,
+            'application/tar',
+            'application/x-tar',
+        )
 
         is_supported = True
 
@@ -444,21 +447,13 @@ class BlackDuckConfig(BacklogItemMixins):
                     f'{access_type=} is not supported for BD scans, {supported_access_types=}',
                 )
 
-        if (
-            artefact_type
-            and access_type
-            and (artefact_types := supported_artefact_types_by_access_type.get(access_type))
-        ):
-            if not any(
-                artefact_type.startswith(supported_artefact_type)
-                for supported_artefact_type in artefact_types
-            ):
-                is_supported = False
-                if self.on_unsupported is WarningVerbosities.WARNING:
-                    logger.warning(
-                        f'{artefact_type=} is not supported for BD scans with {access_type=}, '
-                        f'{supported_artefact_types_by_access_type=}',
-                    )
+        if artefact_type and artefact_type not in supported_artefact_types:
+            is_supported = False
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{artefact_type=} is not supported for BD scans scans, '
+                    f'{supported_artefact_types=}',
+                )
 
         return is_supported
 
@@ -607,7 +602,6 @@ class ClamAVConfig(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
-        artefact_type: str | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
@@ -615,9 +609,6 @@ class ClamAVConfig(BacklogItemMixins):
             ocm.AccessType.LOCAL_BLOB,
             ocm.AccessType.S3,
         )
-        supported_artefact_types_by_access_type = {
-            ocm.AccessType.S3: ('application/tar', 'application/x-tar'),
-        }
 
         is_supported = True
 
@@ -635,22 +626,6 @@ class ClamAVConfig(BacklogItemMixins):
                 logger.warning(
                     f'{access_type=} is not supported for ClamAV scans, {supported_access_types=}',
                 )
-
-        if (
-            artefact_type
-            and access_type
-            and (artefact_types := supported_artefact_types_by_access_type.get(access_type))
-        ):
-            if not any(
-                artefact_type.startswith(supported_artefact_type)
-                for supported_artefact_type in artefact_types
-            ):
-                is_supported = False
-                if self.on_unsupported is WarningVerbosities.WARNING:
-                    logger.warning(
-                        f'{artefact_type=} is not supported for ClamAV scans with {access_type=}, '
-                        f'{supported_artefact_types_by_access_type=}',
-                    )
 
         return is_supported
 
@@ -782,7 +757,7 @@ class CryptoConfig(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
-        artefact_type: str | None = None,
+        artefact_type: ocm.ArtefactType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
@@ -790,10 +765,14 @@ class CryptoConfig(BacklogItemMixins):
             ocm.AccessType.LOCAL_BLOB,
             ocm.AccessType.S3,
         )
-        supported_artefact_types_by_access_type = {
-            ocm.AccessType.OCI_REGISTRY: ('ociImage', 'ociArtifact'),
-            ocm.AccessType.S3: ('application/tar', 'application/x-tar'),
-        }
+        supported_artefact_types = (
+            ocm.ArtefactType.DIRECTORY_TREE,
+            ocm.ArtefactType.EXECUTABLE,
+            ocm.ArtefactType.OCI_ARTEFACT,
+            ocm.ArtefactType.OCI_IMAGE,
+            'application/tar',
+            'application/x-tar',
+        )
 
         is_supported = True
 
@@ -812,21 +791,13 @@ class CryptoConfig(BacklogItemMixins):
                     f'{access_type=} is not supported for crypto scans, {supported_access_types=}',
                 )
 
-        if (
-            artefact_type
-            and access_type
-            and (artefact_types := supported_artefact_types_by_access_type.get(access_type))
-        ):
-            if not any(
-                artefact_type.startswith(supported_artefact_type)
-                for supported_artefact_type in artefact_types
-            ):
-                is_supported = False
-                if self.on_unsupported is WarningVerbosities.WARNING:
-                    logger.warning(
-                        f'{artefact_type=} is not supported for crypto scans with {access_type=}, '
-                        f'{supported_artefact_types_by_access_type=}',
-                    )
+        if artefact_type and artefact_type not in supported_artefact_types:
+            is_supported = False
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{artefact_type=} is not supported for crypto scans, '
+                    f'{supported_artefact_types=}',
+                )
 
         return is_supported
 
@@ -1196,17 +1167,14 @@ class OsId(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
-        artefact_type: str | None = None,
+        artefact_type: ocm.ArtefactType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
             ocm.AccessType.LOCAL_BLOB,
             ocm.AccessType.OCI_REGISTRY,
         )
-        supported_artefact_types_by_access_type = {
-            ocm.AccessType.LOCAL_BLOB: (ocm.ArtefactType.OCI_IMAGE,),
-            ocm.AccessType.OCI_REGISTRY: (ocm.ArtefactType.OCI_IMAGE,),
-        }
+        supported_artefact_types = (ocm.ArtefactType.OCI_IMAGE,)
 
         is_supported = True
 
@@ -1224,21 +1192,12 @@ class OsId(BacklogItemMixins):
                 )
             is_supported = False
 
-        if (
-            artefact_type
-            and access_type
-            and (artefact_types := supported_artefact_types_by_access_type.get(access_type))
-        ):
-            if not any(
-                artefact_type.startswith(supported_artefact_type)
-                for supported_artefact_type in artefact_types
-            ):
-                if self.on_unsupported is WarningVerbosities.WARNING:
-                    logger.warning(
-                        f'{artefact_type=} is not supported for OS_ID scans with {access_type=}, '
-                        f'{supported_artefact_types_by_access_type=}',
-                    )
-                is_supported = False
+        if artefact_type and artefact_type not in supported_artefact_types:
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{artefact_type=} is not supported for OS_ID scans, {supported_artefact_types=}',  # noqa: E501
+                )
+            is_supported = False
 
         return is_supported
 
@@ -1273,7 +1232,7 @@ class SBOMGeneratorConfig(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
-        artefact_type: str | None = None,
+        artefact_type: ocm.ArtefactType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
@@ -1281,11 +1240,14 @@ class SBOMGeneratorConfig(BacklogItemMixins):
             ocm.AccessType.LOCAL_BLOB,
             ocm.AccessType.S3,
         )
-        supported_artefact_types_by_access_type = {
-            ocm.AccessType.OCI_REGISTRY: ('ociImage', 'ociArtifact'),
-            ocm.AccessType.LOCAL_BLOB: ('directoryTree', 'executable'),
-            ocm.AccessType.S3: ('application/tar', 'application/x-tar'),
-        }
+        supported_artefact_types = (
+            ocm.ArtefactType.DIRECTORY_TREE,
+            ocm.ArtefactType.EXECUTABLE,
+            ocm.ArtefactType.OCI_ARTEFACT,
+            ocm.ArtefactType.OCI_IMAGE,
+            'application/tar',
+            'application/x-tar',
+        )
 
         is_supported = True
 
@@ -1305,21 +1267,13 @@ class SBOMGeneratorConfig(BacklogItemMixins):
                     f'{supported_access_types=}',
                 )
 
-        if (
-            artefact_type
-            and access_type
-            and (artefact_types := supported_artefact_types_by_access_type.get(access_type))
-        ):
-            if not any(
-                artefact_type.startswith(supported_artefact_type)
-                for supported_artefact_type in artefact_types
-            ):
-                is_supported = False
-                if self.on_unsupported is WarningVerbosities.WARNING:
-                    logger.warning(
-                        f'{artefact_type=} is not supported for SBOM Generation with '
-                        f'{access_type=}, {supported_artefact_types_by_access_type=}',
-                    )
+        if artefact_type and artefact_type not in supported_artefact_types:
+            is_supported = False
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{artefact_type=} is not supported for SBOM Generation, '
+                    f'{supported_artefact_types=}',
+                )
 
         return is_supported
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -1199,8 +1199,12 @@ class OsId(BacklogItemMixins):
         artefact_type: str | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
-        supported_access_types = (ocm.AccessType.OCI_REGISTRY,)
+        supported_access_types = (
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
+        )
         supported_artefact_types_by_access_type = {
+            ocm.AccessType.LOCAL_BLOB: (ocm.ArtefactType.OCI_IMAGE,),
             ocm.AccessType.OCI_REGISTRY: (ocm.ArtefactType.OCI_IMAGE,),
         }
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -318,8 +318,9 @@ class BDBAConfig(BacklogItemMixins):
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
-            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.S3,
         )
 
@@ -418,8 +419,9 @@ class BlackDuckConfig(BacklogItemMixins):
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
-            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.S3,
         )
         supported_artefact_types = (
@@ -605,8 +607,9 @@ class ClamAVConfig(BacklogItemMixins):
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
-            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.S3,
         )
 
@@ -761,8 +764,9 @@ class CryptoConfig(BacklogItemMixins):
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
-            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.S3,
         )
         supported_artefact_types = (
@@ -1236,8 +1240,9 @@ class SBOMGeneratorConfig(BacklogItemMixins):
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
         supported_access_types = (
-            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+            ocm.AccessType.OCI_REGISTRY,
             ocm.AccessType.S3,
         )
         supported_artefact_types = (

--- a/src/osid_extension/__main__.py
+++ b/src/osid_extension/__main__.py
@@ -89,9 +89,25 @@ def determine_os_status(
 
 def base_image_osid(
     oci_client: oci.client.Client,
+    component: ocm.Component,
     resource: ocm.Resource,
 ) -> odg.model.OperatingSystemId:
-    image_reference = resource.access.imageReference
+    access = resource.access
+
+    if access.type is ocm.AccessType.LOCAL_BLOB:
+        image_reference = component.current_ocm_repo.component_version_oci_ref(
+            name=component.name,
+            version=component.version,
+        )
+        digest = access.localReference.lower()
+
+        image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+    elif access.type is ocm.AccessType.OCI_REGISTRY:
+        image_reference = access.imageReference
+
+    else:
+        raise RuntimeError(f'Unsupported access type: {access.type}')
 
     manifest = oci_client.manifest(
         image_reference=image_reference,
@@ -254,6 +270,7 @@ def process_artefact(
 
     osid: odg.model.OperatingSystemId = base_image_osid(
         oci_client=oci_client,
+        component=resource_node.component,
         resource=resource_node.resource,
     )
 

--- a/src/osid_extension/__main__.py
+++ b/src/osid_extension/__main__.py
@@ -126,7 +126,7 @@ def base_image_osid(
 def create_artefact_metadata(
     artefact: odg.model.ComponentArtefactId,
     osid_finding_config: odg.findings.Finding,
-    osid: odg.model.OperatingSystemId | None,
+    osid: odg.model.OperatingSystemId,
     eol_client: eol.EolClient,
     relation: ocm.ResourceRelation,
     time_now: datetime.datetime | None = None,
@@ -252,7 +252,7 @@ def process_artefact(
             )
         return
 
-    osid: odg.model.OperatingSystemId | None = base_image_osid(
+    osid: odg.model.OperatingSystemId = base_image_osid(
         oci_client=oci_client,
         resource=resource_node.resource,
     )

--- a/src/sbom_generator.py
+++ b/src/sbom_generator.py
@@ -55,6 +55,7 @@ def generate_sbom_with_syft(
     with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
         filename_for_access_type = {
             ocm.AccessType.LOCAL_BLOB: 'local_blob',
+            ocm.AccessType.OCI_BLOB: 'oci_blob',
             ocm.AccessType.OCI_REGISTRY: None,
             ocm.AccessType.S3: 's3',
         }
@@ -65,7 +66,7 @@ def generate_sbom_with_syft(
 
         sbom_raw = syft.generate_raw_sbom_for_artefact(
             component=resource_node.component,
-            access=resource_node.resource.access,
+            access=access,
             secret_factory=secret_factory,
             oci_client=oci_client,
             file_path=file_path,

--- a/src/syft.py
+++ b/src/syft.py
@@ -53,6 +53,127 @@ def run_syft(
     return sbom_raw
 
 
+def _sbom_for_oci_artefact(
+    access: ocm.OciAccess,
+    secret_factory: secret_mgmt.SecretFactory,
+    sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
+) -> str:
+    oci_secret = secret_mgmt.oci_registry.find_cfg(
+        secret_factory=secret_factory,
+        image_reference=access.imageReference,
+    )
+
+    if oci_secret:
+        dockerutil.prepare_docker_cfg(
+            image_reference=access.imageReference,
+            username=oci_secret.username,
+            password=oci_secret.password,
+        )
+
+    return run_syft(
+        source=access.imageReference,
+        output_format=sbom_output_format,
+    )
+
+
+def _sbom_for_s3(
+    access: ocm.S3Access | ocm.LegacyS3Access,
+    secret_factory: secret_mgmt.SecretFactory,
+    file_path: str,
+    aws_secret_name: str | None = None,
+    sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
+) -> str:
+    if hasattr(access, 'mediaType') and access.mediaType:
+        if not util.media_type_supports(access.mediaType, 'tar'):
+            raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
+    else:
+        logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
+
+    aws_secret = secret_mgmt.aws.find_cfg(
+        secret_factory=secret_factory,
+        secret_name=aws_secret_name,
+    )
+    s3_client = aws_secret.session.client('s3')
+
+    if isinstance(access, ocm.LegacyS3Access):
+        bucket = access.bucketName
+        key = access.objectKey
+    else:
+        bucket = access.bucket
+        key = access.key
+
+    fileobj = s3_client.get_object(Bucket=bucket, Key=key)['Body']
+
+    def tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
+        if member.islnk() or member.issym():
+            if os.path.isabs(member.linkname):
+                return None
+        return member
+
+    with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
+        tar.extractall(
+            path=file_path,
+            filter=tar_filter,
+        )
+
+    return run_syft(
+        source=file_path,
+        output_format=sbom_output_format,
+    )
+
+
+def _sbom_for_blob(
+    access: ocm.LocalBlobAccess | ocm.OciBlobAccess,
+    component: ocm.Component,
+    oci_client: oci.client.Client,
+    secret_factory: secret_mgmt.SecretFactory,
+    file_path: str,
+    sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
+) -> str:
+    image_reference = component.current_ocm_repo.component_version_oci_ref(
+        name=component.name,
+        version=component.version,
+    )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB:
+        digest = access.localReference.lower()
+    else:
+        digest = access.digest.lower()
+
+    if access.mediaType in (
+        oci.model.OCI_IMAGE_INDEX_MIME,
+        oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+        oci.model.DOCKER_MANIFEST_LIST_MIME,
+        oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+    ):
+        image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+        return _sbom_for_oci_artefact(
+            access=ocm.OciAccess(imageReference=str(image_reference)),
+            secret_factory=secret_factory,
+            sbom_output_format=sbom_output_format,
+        )
+
+    if access.type is ocm.AccessType.LOCAL_BLOB and access.globalAccess:
+        image_reference = access.globalAccess.ref
+        digest = access.globalAccess.digest.lower()
+
+    blob = oci_client.blob(
+        image_reference=image_reference,
+        digest=digest,
+        stream=True,
+    )
+
+    with open(file_path, 'wb') as file:
+        for chunk in blob.iter_content(chunk_size=4096):
+            file.write(chunk)
+
+    return run_syft(
+        source=file_path,
+        output_format=sbom_output_format,
+    )
+
+
 def generate_raw_sbom_for_artefact(
     component: ocm.Component,
     access: ocm.Access,
@@ -84,146 +205,32 @@ def generate_raw_sbom_for_artefact(
         raise ValueError(f'file_path must not be empty for {access.type=}')
 
     if access.type is ocm.AccessType.OCI_REGISTRY:
-        access: ocm.OciAccess
-
-        oci_secret = secret_mgmt.oci_registry.find_cfg(
+        return _sbom_for_oci_artefact(
+            access=access,
             secret_factory=secret_factory,
-            image_reference=access.imageReference,
-        )
-
-        if oci_secret:
-            dockerutil.prepare_docker_cfg(
-                image_reference=access.imageReference,
-                username=oci_secret.username,
-                password=oci_secret.password,
-            )
-
-        return run_syft(
-            source=access.imageReference,
-            output_format=sbom_output_format,
+            sbom_output_format=sbom_output_format,
         )
 
     elif access.type is ocm.AccessType.S3:
-        access: ocm.S3Access | ocm.LegacyS3Access
-
-        if hasattr(access, 'mediaType') and access.mediaType:
-            if not util.media_type_supports(access.mediaType, 'tar'):
-                raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
-        else:
-            logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
-
-        aws_secret = secret_mgmt.aws.find_cfg(
+        return _sbom_for_s3(
+            access=access,
             secret_factory=secret_factory,
-            secret_name=aws_secret_name,
-        )
-        s3_client = aws_secret.session.client('s3')
-
-        if isinstance(access, ocm.LegacyS3Access):
-            bucket = access.bucketName
-            key = access.objectKey
-        else:
-            bucket = access.bucket
-            key = access.key
-
-        fileobj = s3_client.get_object(Bucket=bucket, Key=key)['Body']
-
-        def tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
-            if member.islnk() or member.issym():
-                if os.path.isabs(member.linkname):
-                    return None
-            return member
-
-        with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
-            tar.extractall(
-                path=file_path,
-                filter=tar_filter,
-            )
-
-        return run_syft(
-            source=file_path,
-            output_format=sbom_output_format,
+            aws_secret_name=aws_secret_name,
+            file_path=file_path,
+            sbom_output_format=sbom_output_format,
         )
 
-    elif access.type is ocm.AccessType.LOCAL_BLOB:
-        access: ocm.LocalBlobAccess
-
-        image_reference = component.current_ocm_repo.component_version_oci_ref(
-            name=component.name,
-            version=component.version,
-        )
-        digest = access.localReference.lower()
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return generate_raw_sbom_for_artefact(
-                component=component,
-                access=ocm.OciAccess(imageReference=str(image_reference)),
-                secret_factory=secret_factory,
-                sbom_output_format=sbom_output_format,
-            )
-
-        if access.globalAccess:
-            image_reference = access.globalAccess.ref
-            digest = access.globalAccess.digest
-
-        blob = oci_client.blob(
-            image_reference=image_reference,
-            digest=digest,
-            stream=True,
-        )
-
-        with open(file_path, 'wb') as file:
-            for chunk in blob.iter_content(chunk_size=4096):
-                file.write(chunk)
-
-        return run_syft(
-            source=file_path,
-            output_format=sbom_output_format,
-        )
-
-    elif access.type is ocm.AccessType.OCI_BLOB:
-        access: ocm.OciBlobAccess
-
-        image_reference = component.current_ocm_repo.component_version_oci_ref(
-            name=component.name,
-            version=component.version,
-        )
-        digest = access.digest.lower()
-
-        if access.mediaType in (
-            oci.model.OCI_IMAGE_INDEX_MIME,
-            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
-            oci.model.DOCKER_MANIFEST_LIST_MIME,
-            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
-            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
-
-            return generate_raw_sbom_for_artefact(
-                component=component,
-                access=ocm.OciAccess(imageReference=str(image_reference)),
-                secret_factory=secret_factory,
-                sbom_output_format=sbom_output_format,
-            )
-
-        blob = oci_client.blob(
-            image_reference=image_reference,
-            digest=digest,
-            stream=True,
-        )
-
-        with open(file_path, 'wb') as file:
-            for chunk in blob.iter_content(chunk_size=4096):
-                file.write(chunk)
-
-        return run_syft(
-            source=file_path,
-            output_format=sbom_output_format,
+    elif access.type in (
+        ocm.AccessType.LOCAL_BLOB,
+        ocm.AccessType.OCI_BLOB,
+    ):
+        return _sbom_for_blob(
+            access=access,
+            component=component,
+            oci_client=oci_client,
+            secret_factory=secret_factory,
+            file_path=file_path,
+            sbom_output_format=sbom_output_format,
         )
 
     else:

--- a/src/syft.py
+++ b/src/syft.py
@@ -11,6 +11,7 @@ import ocm
 import dockerutil
 import secret_mgmt.aws
 import secret_mgmt.oci_registry
+import util
 
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,13 @@ def generate_raw_sbom_for_artefact(
         )
 
     elif access.type is ocm.AccessType.S3:
-        access: ocm.S3Access
+        access: ocm.S3Access | ocm.LegacyS3Access
+
+        if hasattr(access, 'mediaType') and access.mediaType:
+            if not util.media_type_supports(access.mediaType, 'tar'):
+                raise ValueError(f"Don't know how to handle {access.mediaType=} for s3 access")
+        else:
+            logger.warning(f'No mediaType found in {access=}, will assume it is a tar archive')
 
         aws_secret = secret_mgmt.aws.find_cfg(
             secret_factory=secret_factory,

--- a/src/syft.py
+++ b/src/syft.py
@@ -5,6 +5,7 @@ import subprocess
 import tarfile
 
 import oci.client
+import oci.model
 import ocm
 
 import dockerutil
@@ -55,11 +56,17 @@ def generate_raw_sbom_for_artefact(
     component: ocm.Component,
     access: ocm.Access,
     secret_factory: secret_mgmt.SecretFactory,
-    oci_client: oci.client.Client,
+    oci_client: oci.client.Client | None = None,
     file_path: str | None = None,
     aws_secret_name: str | None = None,
     sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
 ) -> str:
+    if (
+        access.type is ocm.AccessType.LOCAL_BLOB
+        and not oci_client
+    ):
+        raise ValueError(f'oci_client must not be empty for {access.type=}')
+
     if (
         access.type
         in (
@@ -126,17 +133,32 @@ def generate_raw_sbom_for_artefact(
         )
 
     elif access.type is ocm.AccessType.LOCAL_BLOB:
-        access: ocm.LocalBlobAccess | ocm.LocalBlobGlobalAccess
+        access: ocm.LocalBlobAccess
+
+        image_reference = component.current_ocm_repo.component_version_oci_ref(
+            name=component.name,
+            version=component.version,
+        )
+        digest = access.localReference.lower()
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return generate_raw_sbom_for_artefact(
+                component=component,
+                access=ocm.OciAccess(imageReference=str(image_reference)),
+                secret_factory=secret_factory,
+                sbom_output_format=sbom_output_format,
+            )
 
         if access.globalAccess:
             image_reference = access.globalAccess.ref
             digest = access.globalAccess.digest
-        else:
-            image_reference = component.current_ocm_repo.component_version_oci_ref(
-                name=component.name,
-                version=component.version,
-            )
-            digest = access.localReference
 
         blob = oci_client.blob(
             image_reference=image_reference,

--- a/src/syft.py
+++ b/src/syft.py
@@ -63,7 +63,11 @@ def generate_raw_sbom_for_artefact(
     sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
 ) -> str:
     if (
-        access.type is ocm.AccessType.LOCAL_BLOB
+        access.type
+        in (
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
+        )
         and not oci_client
     ):
         raise ValueError(f'oci_client must not be empty for {access.type=}')
@@ -72,6 +76,7 @@ def generate_raw_sbom_for_artefact(
         access.type
         in (
             ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.OCI_BLOB,
             ocm.AccessType.S3,
         )
         and not file_path
@@ -166,6 +171,45 @@ def generate_raw_sbom_for_artefact(
         if access.globalAccess:
             image_reference = access.globalAccess.ref
             digest = access.globalAccess.digest
+
+        blob = oci_client.blob(
+            image_reference=image_reference,
+            digest=digest,
+            stream=True,
+        )
+
+        with open(file_path, 'wb') as file:
+            for chunk in blob.iter_content(chunk_size=4096):
+                file.write(chunk)
+
+        return run_syft(
+            source=file_path,
+            output_format=sbom_output_format,
+        )
+
+    elif access.type is ocm.AccessType.OCI_BLOB:
+        access: ocm.OciBlobAccess
+
+        image_reference = component.current_ocm_repo.component_version_oci_ref(
+            name=component.name,
+            version=component.version,
+        )
+        digest = access.digest.lower()
+
+        if access.mediaType in (
+            oci.model.OCI_IMAGE_INDEX_MIME,
+            oci.model.OCI_MANIFEST_SCHEMA_V2_MIME,
+            oci.model.DOCKER_MANIFEST_LIST_MIME,
+            oci.model.DOCKER_MANIFEST_SCHEMA_V2_MIME,
+        ):
+            image_reference = oci.model.OciImageReference(image_reference).with_tag(digest)
+
+            return generate_raw_sbom_for_artefact(
+                component=component,
+                access=ocm.OciAccess(imageReference=str(image_reference)),
+                secret_factory=secret_factory,
+                sbom_output_format=sbom_output_format,
+            )
 
         blob = oci_client.blob(
             image_reference=image_reference,

--- a/src/util.py
+++ b/src/util.py
@@ -361,3 +361,14 @@ def version_sorting_key(
         version = versionutil.parse_to_semver(fallback_version)
 
     return version
+
+
+def media_type_supports(
+    media_type: str,
+    type: str,
+) -> bool:
+    media_type: str = media_type.split(';', 1)[0].lower()
+
+    subtype = media_type.split('/', 1)[-1].replace('+', '.').replace('-', '.')
+
+    return type in subtype.split('.')


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/205

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature operator
OCM's "OCI-native" local blobs are now supported as well as the `OCIImageLayer` access type
```
```noteworthy developer
The extensions (except osid) are not limited anymore to certain _artefact types_ but only _access types_
```
