### PR TITLE
fix(ocm): Check supported artefact types only for matching prefix

### DIFF
--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -449,7 +449,10 @@ class BlackDuckConfig(BacklogItemMixins):
                     f'{access_type=} is not supported for BD scans, {supported_access_types=}',
                 )
 
-        if artefact_type and artefact_type not in supported_artefact_types:
+        if artefact_type and not any(
+            artefact_type.startswith(supported_artefact_type)
+            for supported_artefact_type in supported_artefact_types
+        ):
             is_supported = False
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
@@ -795,7 +798,10 @@ class CryptoConfig(BacklogItemMixins):
                     f'{access_type=} is not supported for crypto scans, {supported_access_types=}',
                 )
 
-        if artefact_type and artefact_type not in supported_artefact_types:
+        if artefact_type and not any(
+            artefact_type.startswith(supported_artefact_type)
+            for supported_artefact_type in supported_artefact_types
+        ):
             is_supported = False
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
@@ -1272,7 +1278,10 @@ class SBOMGeneratorConfig(BacklogItemMixins):
                     f'{supported_access_types=}',
                 )
 
-        if artefact_type and artefact_type not in supported_artefact_types:
+        if artefact_type and not any(
+            artefact_type.startswith(supported_artefact_type)
+            for supported_artefact_type in supported_artefact_types
+        ):
             is_supported = False
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(


### PR DESCRIPTION
**What this PR does / why we need it**:
Required to support variants like `application/tar+vm-image-rootfs` instead of `application/tar`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/205

**Special notes for your reviewer**:

- [ ] ~Unit tests created for new code or existing unit tests updated (if applicable)~
- [ ] ~End-user documentation updated (if applicable)~

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
