### PR TITLE
feat(uv): Workaround to pin versions with pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN uv export --frozen --no-dev --no-emit-project --no-emit-workspace \
         --format=requirements-txt -o constraints.txt
 
 ARG ODG_CORE_LIBS_VERSION
-COPY dist/ /dist/
-RUN uv venv "$VIRTUAL_ENV" \
+RUN --mount=type=bind,source=dist/,target=/dist \
+    uv venv "$VIRTUAL_ENV" \
  && uv pip install --no-cache --find-links /dist \
         --constraint constraints.txt \
-        odg-core-libs==${ODG_CORE_LIBS_VERSION} \
+        odg-core-libs==${ODG_CORE_LIBS_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,15 @@ COPY src/malware/clamd.conf /etc/clamav/clamd.conf
 COPY --from=cbomkit-theia-builder /cbomkit-theia/cbomkit-theia /usr/bin/cbomkit-theia
 
 RUN apk add --no-cache \
-    bash \
-    ca-certificates \
-    clamav \
-    clamav-libunrar \
-    curl \
-    git \
-    helm \
-    postgresql16-client \
-    syft \
+    bash=5.3.9-r1 \
+    ca-certificates=20260611-r0 \
+    clamav=1.4.6-r0 \
+    clamav-libunrar=1.4.6-r0 \
+    curl=8.21.0-r0 \
+    git=2.54.0-r0 \
+    helm=3.19.0-r7 \
+    postgresql16-client=16.15-r0 \
+    syft=1.42.4-r1 \
  && curl https://aia.pki.co.sap.com/aia/SAP%20Global%20Root%20CA.crt -o \
     /usr/local/share/ca-certificates/SAP_Global_Root_CA.crt \
  && curl https://aia.pki.co.sap.com/aia/SAPNetCA_G2_2.crt -o \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,17 @@ RUN apk add --no-cache \
  && mkdir /freshclam \
  && chown clamav /freshclam
 
-ARG ODG_CORE_LIBS_VERSION
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Workaround to pin versions for pip install with local deps 
+COPY uv.lock pyproject.toml ./
+RUN uv export --frozen --no-dev --no-emit-project --no-emit-workspace \
+        --format=requirements-txt -o constraints.txt
+
+ARG ODG_CORE_LIBS_VERSION
 COPY dist/ /dist/
 RUN uv venv "$VIRTUAL_ENV" \
- && uv pip install --no-cache --find-links /dist odg-core-libs==${ODG_CORE_LIBS_VERSION} \
- && rm -rf /dist
+ && uv pip install --no-cache --find-links /dist \
+        --constraint constraints.txt \
+        odg-core-libs==${ODG_CORE_LIBS_VERSION} \


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that python dependencies are pinned properly in the Docker container.

**Background**
- We are installing our odg-core/ bdba / odg-libs from wheels in the Dockerfile
- Wheels don't pin versions:
```
Metadata-Version: 2.4
Name: bdba-client
Version: 0.16.0
Requires-Dist: cachecontrol
Requires-Dist: dacite
Requires-Dist: python-dateutil
Requires-Dist: requests
Dynamic: requires-dist
```
- Thus pip install would just fetch any versions, not those in the uv file
-  Therefore we generate a contraints.txt file from the uv lock that pip can use to pin version.

**Note**
Our own packages `bdba-client` and `odg-client` are not pinned. Depending on whether they are build in the `dist` folder locally, pip would try to take the local ones and if not take the newest version published on pypi. This is a convenient compromise.

**Which issue(s) this PR fixes**:
Fixes  https://github.com/open-component-model/open-delivery-gear/issues/222

**Special notes for your reviewer**:

- [ ] Unit tests created for new code or existing unit tests updated (if applicable)
- [ ] End-user documentation updated (if applicable)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
