### PR TITLE
fix(test): Freeze Date on Test Responsibles Heuristics

### DIFF
--- a/src/test/test_responsibles_heuristic.py
+++ b/src/test/test_responsibles_heuristic.py
@@ -1,8 +1,20 @@
+import calendar
+import time
+
 import pytest
 import yaml
+from unittest.mock import patch
 
 import paths
 import responsibles.github_statistics as rg
+
+# global_stats() weights commits by age relative to time.time(). The test
+# fixtures contain historical contributor data (2020-2022). As real time
+# advances, the sigmoid re-fit shifts which authors fall into the percentile
+# brackets, making the assertion unstable. Freeze to a fixed epoch so the
+# test is deterministic regardless of when it runs.
+# See: test_responsibles_heuristic_time_sensitivity.md
+_FROZEN_EPOCH = calendar.timegm(time.strptime('2023-06-01', '%Y-%m-%d'))
 
 
 @pytest.fixture()
@@ -15,6 +27,15 @@ def negative_list():
 def positive_list():
     with open(paths.test_resources_gardener_org_members, 'r') as f:
         return yaml.load(f, Loader=yaml.SafeLoader)['usernames']
+
+
+@pytest.fixture(autouse=True)
+def freeze_time():
+    with patch(
+        'responsibles.github_statistics.time.time',
+        return_value=_FROZEN_EPOCH,
+    ):
+        yield
 
 
 def _is_candidate_stat(


### PR DESCRIPTION
**What this PR does / why we need it**:

# `test_responsibles_heuristic` — Time Sensitivity

## Problem

`test_responsibles_heuristic.py::test_apiserver` started failing with:

```
AssertionError: assert {'vpnachev'} == {'ScheererJ', 'vpnachev'}
```

No code change caused this — the test broke on its own as real time advanced.

## Root Cause

`global_stats()` in `src/responsibles/github_statistics.py` computes commit
and lines-of-code weights relative to `int(time.time())` (the current wall
clock). The test fixtures (`apiserver-proxy.json`, `mcm.json`) contain
historical GitHub contributor statistics with commits from 2020–2022.

The sigmoid weighting function is re-fitted based on `repo_age_in_days`
(= `now - first_commit_week`). As real time advances, the repo age grows and
the fitted sigmoid parameters shift, changing which authors fall into the
85th-percentile brackets.

### Why it tipped

For the `apiserver-proxy` data, the weighted commit counts of `vpnachev`
and `ScheererJ` are nearly identical:

| Author     | Weighted commits |
|------------|------------------|
| vpnachev   | 0.357595         |
| ScheererJ  | 0.357413         |

They differ by only ~0.0002. At `repo_age_in_days >= 2419` (≈ Aug 2026),
`ScheererJ` drops below the percentile threshold in both the commit and LoC
stats, so the heuristic intersection yields only `{'vpnachev'}`.

## Fix

An `autouse` fixture freezes `time.time()` to a fixed epoch (`2023-06-01`)
via `unittest.mock.patch`, making the test deterministic regardless of when
it runs. No new dependencies were introduced.

The frozen date was chosen to be shortly after the latest commit in the test
fixtures (May 2022), giving a `repo_age_in_days` of 1243 — comfortably within
the passing range.

## Affected Tests

- `test_apiserver` — expects `{'vpnachev', 'ScheererJ'}`
- `test_mcm` — expects `{'himanshu-kun', 'ialidzhikov'}` (also covered by the
  same freeze, though it was not yet failing)

## Conclusion

This was the only test in the repo with this failure mode. Other time-using
tests either rely on relative deltas (e.g. `now ± timedelta`) or pass
explicit dates — neither breaks as wall-clock time advances. The unique
problem here was static historical fixtures combined with an implicit
`time.time()` call and a hardcoded assertion on percentile membership.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- [ ] Unit tests created for new code or existing unit tests updated (if applicable)
- [ ] End-user documentation updated (if applicable)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
