### PR TITLE
fix(deploy): SAP certificate issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ RUN --mount=type=bind,source=dist/,target=/dist \
     uv venv "$VIRTUAL_ENV" \
  && uv pip install --no-cache --find-links /dist \
         --constraint constraints.txt \
-        odg-core-libs==${ODG_CORE_LIBS_VERSION}
+        odg-core-libs==${ODG_CORE_LIBS_VERSION} \
+ && ln -sf /etc/ssl/certs/ca-certificates.crt "$(python -m certifi)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Several pods on our dev landscape are currently crashing with a SSLError. I think this might be related to the recent changes of the [Dockerfile](https://github.com/open-component-model/odg-core/blob/master/Dockerfile).

I think the reason is that py3-scipy is not longer installed as alpine package which in the past linked Python's trust store to the default trust bundle (see related [change](https://github.com/open-component-model/odg-core/commit/73919423a3449e62f54d6cf9fc4de8c6ba8f092f)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- [ ] Unit tests created for new code or existing unit tests updated (if applicable)
- [ ] End-user documentation updated (if applicable)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
