### PR TITLE
Filter out nvd.nist.gov URLs from GitHub reports

### DIFF
--- a/src/issue_replicator/github.py
+++ b/src/issue_replicator/github.py
@@ -1368,7 +1368,9 @@ def vulnerability_summary(
         urls = set()
         for finding in finding_group.findings:
             if isinstance(finding.finding.data, odg.model.BDBAVulnerabilityFinding):
-                urls.update(finding.finding.data.urls)
+                for url in finding.finding.data.urls:
+                    if 'nvd.nist.gov' not in url:
+                        urls.add(url)
         return sorted(urls)
 
     def group_aggregated_findings(

--- a/src/issue_replicator/github.py
+++ b/src/issue_replicator/github.py
@@ -1367,10 +1367,9 @@ def vulnerability_summary(
         # only return URLs for BDBA findings, to link to the BDBA report
         urls = set()
         for finding in finding_group.findings:
-            if isinstance(finding.finding.data, odg.model.BDBAVulnerabilityFinding):
-                for url in finding.finding.data.urls:
-                    if 'nvd.nist.gov' not in url:
-                        urls.add(url)
+            finding_data = finding.finding.data
+            if isinstance(finding_data, odg.model.BDBAVulnerabilityFinding):
+                urls.add(f'[BDBA {finding_data.product_id}]({finding_data.report_url})')
         return sorted(urls)
 
     def group_aggregated_findings(

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -533,10 +533,6 @@ class BDBAVulnerabilityFinding(VulnerabilityFinding, BDBAMixin):
     def __post_init__(self):
         if self.cvss_score is None and self.cvss_v3_score is not None:
             self.cvss_score = self.cvss_v3_score
-        if self.report_url:
-            bdba_link = f'[BDBA {self.product_id}]({self.report_url})'
-            if bdba_link not in self.urls:
-                self.urls.append(bdba_link)
         super().__post_init__()
 
 

--- a/src/test/test_scanner_utils.py
+++ b/src/test/test_scanner_utils.py
@@ -324,63 +324,6 @@ class TestMakeArtefactScanInfo:
         assert bdba.key != clamav.key
 
 
-class TestBDBAVulnerabilityFindingUrls:
-    def test_report_url_added_to_urls_on_construction(self):
-        finding = odg.model.BDBAVulnerabilityFinding(
-            severity='MEDIUM',
-            package_name='pkg',
-            package_version='1.0',
-            cve='CVE-2024-0001',
-            cvss_score=5.0,
-            base_url='https://bdba.example',
-            report_url='https://bdba.example/report/42',
-            product_id=42,
-            group_id=7,
-        )
-
-        assert any('bdba.example/report/42' in u for u in finding.urls)
-        assert any('nvd.nist.gov' in u for u in finding.urls)
-
-    def test_report_url_not_duplicated_when_already_present(self):
-        bdba_link = '[BDBA 42](https://bdba.example/report/42)'
-        finding = odg.model.BDBAVulnerabilityFinding(
-            severity='MEDIUM',
-            package_name='pkg',
-            package_version='1.0',
-            cve='CVE-2024-0001',
-            cvss_score=5.0,
-            base_url='https://bdba.example',
-            report_url='https://bdba.example/report/42',
-            product_id=42,
-            group_id=7,
-            urls=[bdba_link],
-        )
-
-        assert finding.urls.count(bdba_link) == 1
-
-    def test_urls_not_part_of_finding_key(self):
-        # Ensures that adding the BDBA link to urls on deserialization does not change the key,
-        # preventing accidental key drift between old and new DB records.
-        base_kwargs = dict(
-            severity='MEDIUM',
-            package_name='pkg',
-            package_version='1.0',
-            cve='CVE-2024-0001',
-            cvss_score=5.0,
-            base_url='https://bdba.example',
-            report_url='https://bdba.example/report/42',
-            product_id=42,
-            group_id=7,
-        )
-        without_extra_url = odg.model.BDBAVulnerabilityFinding(**base_kwargs)
-        with_extra_url = odg.model.BDBAVulnerabilityFinding(
-            **base_kwargs,
-            urls=['https://extra.example'],
-        )
-
-        assert without_extra_url.key == with_extra_url.key
-
-
 class TestIterPackageVersionOverwrites:
     def test_from_resource_label(self):
         label = ocm.Label(

--- a/src/test/test_vulnerability_finding.py
+++ b/src/test/test_vulnerability_finding.py
@@ -169,3 +169,19 @@ def test_nvd_url_not_added_for_non_cve():
         cvss_score=5.3,
     )
     assert finding.urls == []
+
+
+def test_bdba_finding_only_nvd_url_added():
+    finding = odg.model.BDBAVulnerabilityFinding(
+        severity='MEDIUM',
+        package_name='pkg',
+        package_version='1.0',
+        cve='CVE-2024-0001',
+        cvss_score=5.0,
+        base_url='https://bdba.example',
+        report_url='https://bdba.example/report/42',
+        product_id=42,
+        group_id=7,
+    )
+    assert not any('bdba.example/report/42' in u for u in finding.urls)
+    assert any('nvd.nist.gov' in u for u in finding.urls)


### PR DESCRIPTION
**What this PR does / why we need it**:

Filter out nvd.nist.gov URLs that were introduced with the vulnerability finding remodeling