### PR TITLE
feat(charts): Add (optional) Gateway resource to Delivery-Service chart

### DIFF
--- a/charts/delivery-service/templates/gateway.yaml
+++ b/charts/delivery-service/templates/gateway.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gateway.enabled }}
+{{- $name := .Values.gateway.fullnameOverride }}
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+  {{- if default dict (.Values.gateway).annotations }}
+  annotations:
+    {{- range $annotation, $value := default dict .Values.gateway.annotations }}
+    {{ $annotation }}: {{ $value }}
+    {{- end }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gateway.className }}
+  listeners:
+  {{- if .Values.gateway.enableTls }}
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: "{{ $name }}-tls"
+  {{- else }}
+    - name: http
+      port: 80
+      protocol: HTTP
+  {{- end }}
+{{- end }}

--- a/charts/delivery-service/values.yaml
+++ b/charts/delivery-service/values.yaml
@@ -12,4 +12,10 @@ deployment:
     limits:
       memory: 5Gi
       cpu: 500m
+gateway:
+  annotations: {}
+  className: envoy-gateway
+  enabled: false
+  enableTls: true
+  fullnameOverride: open-delivery-gear
 host: delivery-service


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the provisioning of ODG via OCP, an envoy gateway is deployed into the workload cluster by utilising the existing platform service gateway. Hence, the networking related Helm charts defined in https://github.com/open-component-model/open-delivery-gear are not necessary anymore in that use case. However, the definition of a Gateway resource matching the existing HTTPRoutes is still necessary.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- [ ] Unit tests created for new code or existing unit tests updated (if applicable)
- [ ] End-user documentation updated (if applicable)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy developer
The Delivery-Service Helm chart now includes an optional Gateway resource necessary for the provisioning on the OCP platform
```
