### PR TITLE
chore(renovate): group gardener python libs together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
   packageRules: [
     {
       matchDepNames: ['gardener-cicd-libs', 'gardener-ocm', 'gardener-oci'],
-      groupName: 'ocm deps',
+      groupName: 'gardner python deps',
     },
     {
       // Majors wait as checkboxes in the dependency dashboard ("Pending

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,10 @@
   },
   packageRules: [
     {
+      matchDepNames: ['gardener-cicd-libs', 'gardener-ocm', 'gardener-oci'],
+      groupName: 'ocm deps',
+    },
+    {
       // Majors wait as checkboxes in the dependency dashboard ("Pending
       // Approval") instead of occupying prConcurrentLimit slots — tick one
       // there to have its PR created when you're ready to work on it.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
   packageRules: [
     {
       matchDepNames: ['gardener-cicd-libs', 'gardener-ocm', 'gardener-oci'],
-      groupName: 'gardner python deps',
+      groupName: 'gardener python deps',
     },
     {
       // Majors wait as checkboxes in the dependency dashboard ("Pending


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of opening 3 PRs of those deps that are always released in sync, they can be grouped together.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- [ ] Unit tests created for new code or existing unit tests updated (if applicable)
- [ ] End-user documentation updated (if applicable)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
